### PR TITLE
WIP: Use ImagesetCollection for referring to imagetagger collections

### DIFF
--- a/MLHelper/_image_label_reader/ImageLabelReader.py
+++ b/MLHelper/_image_label_reader/ImageLabelReader.py
@@ -1,13 +1,14 @@
-from typing import List
+from typing import List, Union
 
 from .ImageReader import Reader as ImgReader
 from .LabelReader import Reader as LblReader
 from .ImageBatch import ImageBatch
+from ..datasets.bitbots import ImagesetCollection
 
 
 class DataObject:
 
-    def __init__(self, pathlist : List[str],
+    def __init__(self, collection_or_paths : Union[ImagesetCollection, List[str]],
                  label_content : str = None,
                  batch_size : int = 1,
                  queue_size : int = 64,
@@ -22,7 +23,10 @@ class DataObject:
         :param batch_size: size of the image data batches that will be loaded
         """
         # init variables
-        self._pathlist = pathlist
+        if isinstance(collection_or_paths, ImagesetCollection):
+            self._pathlist = collection_or_paths.to_paths()
+        else:
+            self._pathlist = collection_or_paths
         self._batch_size = batch_size
         self._labels = LblReader(self._pathlist, label_content=label_content, img_dim=img_dim)
         self._images = ImgReader(self._pathlist, label_content=label_content, batch_size=self._batch_size,

--- a/MLHelper/_image_label_reader/ImageLabelReader.py
+++ b/MLHelper/_image_label_reader/ImageLabelReader.py
@@ -18,7 +18,7 @@ class DataObject:
         """
         constructor
 
-        :param pathlist: a list containing valid paths containing images and labels
+        :param collection_or_paths: an ImagesetCollection instance or a list containing valid paths containing images and labels
 
         :param batch_size: size of the image data batches that will be loaded
         """

--- a/MLHelper/_image_label_reader/ImageReader.py
+++ b/MLHelper/_image_label_reader/ImageReader.py
@@ -1,5 +1,5 @@
 import os, sys
-from typing import List, Dict
+from typing import List, Dict, Union
 from itertools import cycle
 import numpy as np
 import cv2
@@ -9,10 +9,11 @@ import math
 
 from .PathImageFinder import ImgFind
 from .PathImageFinderFilterLabels import ImgFindFilter
+from ..datasets.bitbots import ImagesetCollection
 
 
 class Reader:
-    def __init__(self, pathlist: List[str],
+    def __init__(self, collection_or_paths: Union[ImagesetCollection, List[str]],
                  label_content: str = None,
                  batch_size: int = 1,
                  queue_size: int = 16,
@@ -21,14 +22,17 @@ class Reader:
                  wait_for_queue_full=True,
                  filter_labels=False):
         """
-        :param pathlist: a list containing valid paths that hold images
+        :param collection_or_paths: an ImagesetCollection instance or a list containing valid paths that hold images
         :param batch_size: size of the image data batches that will be loaded
         :param img_dim: resize images to given dimensions - None by default
         :param wait_for_queue_full: toggles if main thread should wait for the queue to be full before continuing
         :param processes: number of processes to start as workers for loading images
         """
         # init variables
-        self._pathlist = pathlist
+        if isinstance(collection_or_paths, ImagesetCollection):
+            self._pathlist = collection_or_paths.to_paths()
+        else:
+            self._pathlist = collection_or_paths
         self._batch_size = batch_size
         self._img_paths = np.zeros(1)
         self._file_cycler = None

--- a/MLHelper/_image_label_reader/LabelReader.py
+++ b/MLHelper/_image_label_reader/LabelReader.py
@@ -14,7 +14,7 @@ class Reader:
                  label_content: str,
                  img_dim: tuple = None):
         """
-        :param pathlist: a list containing valid paths that hold images
+        :param collection_or_paths: an ImagesetCollection instance or a list containing valid paths that hold images
         :param img_dim: resize images to given dimensions - None by default
         """
         # init variables

--- a/MLHelper/_image_label_reader/LabelReader.py
+++ b/MLHelper/_image_label_reader/LabelReader.py
@@ -3,19 +3,25 @@ import os
 import glob
 import math
 import time
-from typing import List, Dict
+from typing import List, Dict, Union
 from collections import defaultdict
 from .LabelObjects import LabelBoundingBox2D
+from ..datasets.bitbots import ImagesetCollection
 
 
 class Reader:
-    def __init__(self, pathlist: List[str], label_content: str, img_dim: tuple = None):
+    def __init__(self, collection_or_paths: Union[ImagesetCollection, List[str]],
+                 label_content: str,
+                 img_dim: tuple = None):
         """
         :param pathlist: a list containing valid paths that hold images
         :param img_dim: resize images to given dimensions - None by default
         """
         # init variables
-        self._pathlist = pathlist
+        if isinstance(collection_or_paths, ImagesetCollection):
+            self._pathlist = collection_or_paths.to_paths()
+        else:
+            self._pathlist = collection_or_paths
         self._label_content = label_content
         self._img_dim = img_dim
         self._labels = defaultdict(list)

--- a/MLHelper/datasets/bitbots/__init__.py
+++ b/MLHelper/datasets/bitbots/__init__.py
@@ -1,6 +1,7 @@
 from ._bitbots import BallDatasetHandler
 from ._bitbots import NegativeBallDatasetHandler
 from ._bitbots import RandomDatasetHandler
+from ._bitbots import ImagesetCollection
 
 import os
 

--- a/tests/test_BitbotsDatasetHandlers.py
+++ b/tests/test_BitbotsDatasetHandlers.py
@@ -22,23 +22,26 @@ class TestDatasetHandler(unittest.TestCase):
 
     def _test_paths_prepended(self, dataset_tuple, tuple_name):
         mock_path = TestDatasetHandler.mock_path
-        for collection, paths in dataset_tuple._asdict().items():
-            for i, path in enumerate(paths):
+        for collection_name, collection in dataset_tuple._asdict().items():
+            for i, path in enumerate(collection.to_paths()):
                 expected_prefix = mock_path + os.path.sep
                 self.assertTrue(path.startswith(expected_prefix),
-                                f'Expected path at {tuple_name}.{collection}[{i}] to start with "{expected_prefix}", actual: {repr(path)}')
+                                f'Expected path at {tuple_name}.{collection_name}[{i}] to start with "{expected_prefix}", actual: {repr(path)}')
 
     def _test_has_dataset_paths(self, expected_keys, dataset_tuple, tuple_name):
         for key in expected_keys:
             self.assertIn(key, dataset_tuple._fields)
-            paths = getattr(dataset_tuple, key)
-            self.assertIsInstance(paths, frozenset)
+            collection = getattr(dataset_tuple, key)
+            self.assertIsInstance(collection, datasets.ImagesetCollection)
+            paths = collection.to_paths()
+            self.assertIsInstance(paths, list)
             self.assertGreater(len(paths), 0, f"dataset {tuple_name}.{key} should have non-zero path items")
 
     def _test_dataset_all_has_all_paths(self, dataset_tuple):
         all_collections = (getattr(dataset_tuple, key) for key in dataset_tuple._fields)
-        all_paths = set(path for path in chain(*all_collections))
-        self.assertSetEqual(set(getattr(dataset_tuple, "ALL")), all_paths)
+        all_collection_paths = (collection.to_paths() for collection in all_collections)
+        all_paths = set(path for path in chain(*all_collection_paths))
+        self.assertSetEqual(set(getattr(dataset_tuple, "ALL").to_paths()), all_paths)
 
 
 class TestBallDatasetHandler(TestDatasetHandler):


### PR DESCRIPTION
- Add `ImagesetCollection` class
- Use `ImagesetCollection` instead of paths in bitbots dataset handlers
- `LabelReader` now supports `ImagesetCollection` or `List[str]`
- `ImageReader` now supports `ImagesetCollection` or `List[str]`
- `ImageLabelReader` now supports `ImagesetCollection` or `List[str]`

TODO:
- [ ] Tests for `ImagesetCollection`
- [ ] Test that all `ImagesetCollection`s in bitbots dataset handlers are convertible (`to_ids`, `to_paths`, `to_names`)